### PR TITLE
Array#to_h doesn't exist prior to ruby version 2.1

### DIFF
--- a/lib/octodmin/post.rb
+++ b/lib/octodmin/post.rb
@@ -68,9 +68,9 @@ module Octodmin
         "force" => true,
       })
 
-      options = @site.config["octodmin"]["front_matter"].keys.map do |key|
+      options = Hash[@site.config["octodmin"]["front_matter"].keys.map do |key|
         [key, params[key]]
-      end.to_h
+      end]
 
       content = params["content"].gsub("\r\n", "\n").strip
       result = "---\n#{options.map { |k, v| "#{k}: \"#{v}\"" }.join("\n")}\n---\n\n#{content}\n"


### PR DESCRIPTION
This change conditionally loads the backports gem in order to
support older versions. The specific error was being thrown here:

https://github.com/krasnoukhov/octodmin/blob/master/lib/octodmin/post.rb#L73
